### PR TITLE
fix: light mode styling

### DIFF
--- a/src/components/Certifications.astro
+++ b/src/components/Certifications.astro
@@ -23,11 +23,11 @@ const certifications = [
         rel="noopener noreferrer"
         class="flex items-center gap-6 group"
       >
-        <div class="w-12 h-12 flex-shrink-0 flex items-center justify-center">
+        <div class="w-12 h-12 flex-shrink-0 flex items-center justify-center bg-zinc-800 dark:bg-transparent rounded p-2 dark:p-0">
           <img 
             src={`/certifications/${cert.logo}.svg`}
             alt={`${cert.issuer} logo`}
-            class="w-12 h-12 object-contain cert-logo"
+            class="w-12 h-12 object-contain cert-logo filter brightness-0 invert"
             loading="lazy"
           />
         </div>

--- a/src/components/Clients.astro
+++ b/src/components/Clients.astro
@@ -22,11 +22,11 @@ const clients = [
   <p class="sr-only">Logos of companies I've worked with as a consultant or contractor</p>
   <div class="grid grid-cols-2 md:grid-cols-4 gap-6" role="list">
     {clients.slice(0, 12).map(client => (
-      <div class="flex items-center justify-center p-4" role="listitem">
+      <div class="flex items-center justify-center p-4 bg-zinc-800 dark:bg-transparent rounded" role="listitem">
         <img 
           src={`/clients/${client.slug}.svg`}
           alt={`${client.name} logo`}
-          class="max-h-12 w-auto object-contain client-logo"
+          class="max-h-12 w-auto object-contain client-logo filter brightness-0 invert"
           style={client.scale ? `transform: scale(${client.scale * 0.85})` : 'transform: scale(0.85)'}
           loading="lazy"
           onerror="this.style.display='none'; this.nextElementSibling.style.display='flex'"
@@ -40,10 +40,6 @@ const clients = [
 </section>
 
 <style>
-  .client-logo {
-    filter: brightness(0) invert(1);
-  }
-  
   img[style*="display: none"] + span {
     display: flex !important;
   }


### PR DESCRIPTION
This pull request updates the visual styling of certification and client logos to improve consistency and dark mode support. The most important changes are grouped below:

**Styling and Dark Mode Improvements:**

* Certification logos in `Certifications.astro` now have a dark background and rounded corners, with padding adjusted for light/dark modes, and their images use a filter for better visibility in dark mode.
* Client logos in `Clients.astro` now have a dark background, rounded corners, and use a filter for improved dark mode appearance.

**Codebase Cleanup:**

* Removed the global CSS filter from the `.client-logo` class in favor of inline styling on the image elements, streamlining the code and reducing redundancy.